### PR TITLE
Configure Node 20 for Railway deployment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.setup]
+nixPkgs = ["nodejs-20_x", "npm-10_x"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,10 @@
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
       },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      },
       "optionalDependencies": {
         "ioredis": "^5.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.65.0",
     "@mastra/core": "^0.19.1",


### PR DESCRIPTION
## Summary
- Add engines field to package.json requiring Node 20+
- Create nixpacks.toml to explicitly use Node 20 on Railway
- Regenerate package-lock.json to include missing ioredis dependencies

## Problem
Railway deployment was using Node 18 instead of Node 20, causing compatibility issues. Additionally, package-lock.json was missing ioredis dependencies.

## Solution
This PR ensures Railway uses Node 20 by:
1. Adding explicit engine requirements in package.json
2. Creating nixpacks.toml with Node 20 configuration for Railway
3. Fixing package-lock.json integrity issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)