### PR TITLE
Fix Docker build: Skip prepare script to avoid husky error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install dependencies (skip prepare script to avoid husky in production)
+RUN npm ci --only=production --ignore-scripts
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- Fix Railway Docker build by skipping the prepare script during npm install

## Problem
Railway deployment was failing during Docker build with this error:
```
> field-diagnostic-agent@1.0.0 prepare
> husky
sh: 1: husky: not found
npm error code 127
```

The `prepare` script in package.json runs `husky` to set up git hooks, but:
1. Husky is a dev dependency and not installed in production mode
2. Git hooks aren't needed in Docker containers anyway

## Solution
Added `--ignore-scripts` flag to `npm ci` in the Dockerfile to skip all lifecycle scripts including the prepare script.

## Changes
- **Dockerfile**: Change `npm ci --only=production` to `npm ci --only=production --ignore-scripts`

## Impact
- Fixes Railway Docker build error
- Prevents unnecessary git hook setup in production containers
- Allows deployment to proceed successfully

## Test Plan
- [ ] Railway Docker build succeeds
- [ ] Application starts correctly on Railway
- [ ] No husky errors in build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)