### PR TITLE
Fix Docker build: Install all deps, build, then prune

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,17 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies (skip prepare script to avoid husky in production)
-RUN npm ci --only=production --ignore-scripts
+# Install all dependencies including dev (skip prepare script to avoid husky)
+RUN npm ci --ignore-scripts
 
 # Copy source code
 COPY . .
 
 # Build TypeScript
 RUN npm run build
+
+# Remove dev dependencies to reduce image size
+RUN npm prune --production
 
 # Expose port (Railway will override this with PORT env var)
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Fix Railway Docker build by installing all dependencies (including dev) for the TypeScript build step

## Problem
The previous fix added `--ignore-scripts` to avoid the husky error, but used `--only=production` which skips dev dependencies. This caused a new error:
```
> tsc
sh: 1: tsc: not found
```

TypeScript (`tsc`) is a dev dependency and is required to build the application.

## Solution
Updated the Dockerfile build process:
1. Install **all** dependencies (including dev) with `--ignore-scripts` 
2. Build TypeScript using `tsc`
3. Run `npm prune --production` to remove dev dependencies and reduce final image size

## Changes
- **Dockerfile**: 
  - Change `npm ci --only=production --ignore-scripts` to `npm ci --ignore-scripts`
  - Add `npm prune --production` after build step

## Impact
- ✅ Fixes husky prepare script error (via `--ignore-scripts`)
- ✅ Fixes tsc not found error (by installing all deps before build)
- ✅ Optimizes final image size (by pruning dev deps after build)
- ✅ Allows Railway deployment to succeed

## Test Plan
- [ ] Railway Docker build succeeds
- [ ] TypeScript compilation completes successfully
- [ ] Application starts correctly on Railway
- [ ] Final image doesn't include unnecessary dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)