### PR TITLE
Fix production startup: Use node instead of tsx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ RUN npm prune --production
 # Expose port (Railway will override this with PORT env var)
 EXPOSE 3000
 
-# Start the application
-CMD ["npm", "run", "server"]
+# Start the application (use compiled JS, not tsx)
+CMD ["node", "dist/server.js"]

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "npm run server",
+    "startCommand": "node dist/server.js",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
## Summary
- Fix Railway deployment crash by using compiled JavaScript instead of tsx for production startup

## Problem
Railway server keeps crashing with:
```
sh: 1: tsx: not found
> field-diagnostic-agent@1.0.0 server
> tsx src/server.ts
```

This happens because:
1. `tsx` is a dev dependency
2. After `npm prune --production`, dev dependencies are removed
3. The startup command tries to use tsx which no longer exists

## Solution
Change the startup command to use the compiled JavaScript:
- **Before**: `npm run server` (uses tsx)
- **After**: `node dist/server.js` (uses compiled output)

## Changes
- **Dockerfile**: Change CMD from `npm run server` to `node dist/server.js`
- **railway.json**: Change startCommand from `npm run server` to `node dist/server.js`

## Impact
- ✅ Fixes server crash loop on Railway
- ✅ Uses production-ready compiled JavaScript
- ✅ No dependency on tsx in production
- ✅ Faster startup (no TypeScript compilation at runtime)

## Test Plan
- [ ] Railway deployment succeeds
- [ ] Server starts without errors
- [ ] No "tsx: not found" errors in logs
- [ ] Application runs correctly on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)